### PR TITLE
Dev => Master: Urgent build changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
  - export ARTIFACTS=$(pwd)
  - cd ../
  - export ARM_EABI=$(pwd)
+ - sudo apt-get update
  - sudo apt-get install -qq --force-yes libgd2-xpm ia32-libs ia32-libs-multiarch
 install:
  - cd $ARM_EABI

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ COPRE-RaspberryPi-Baremetal
 
 ####CT6COPRE Project
 'Console Programming Resolution' project - Baremetal functionality on the Raspberry Pi. 
-This is a university project - we are not currently accepting submissions.
+This is a university project - we are __not__ currently accepting submissions.
 Project template based on the [Baking Pi tutorials](www.cl.cam.ac.uk/projects/raspberrypi/tutorials/os).
 
 ####Authors:


### PR DESCRIPTION
Perform 'sudo apt-get update' before installing dependencies to avoid a 'unable to fetch some archives' error, as in build: https://travis-ci.org/nweedon/COPRE-RaspberryPi-Baremetal/builds/36253454
